### PR TITLE
Changed automated deployment branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,5 +18,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }} # GitHub token for permissions
           publish_dir: ./ # The directory to deploy (use "." for the root or specify a subdirectory)
-          publish_branch: main # Branch to deploy to (default is `gh-pages`)
+          publish_branch: gh-pages # Branch to deploy to (default is `gh-pages`)
           destination_dir: tinyfoot-demo # The subdirectory on the GitHub Pages site


### PR DESCRIPTION
## Authors
@SushaanthSrinivasan 

## Describe the issue/motivation
Changed automated deployment branch, as github doesn't allow overwriting same main branch for safety

## Describe your changes
Changed publish_branch to gh-pages instead of main

## Issue ticket number and link
Update to solution for Issue #4 - CI/CD pipelines